### PR TITLE
Fix: Rename namespace to prevent detection by ionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Used as `disableScroll` was removed from [`cordova-plugin-ionic-keyboard`](https://github.com/ionic-team/cordova-plugin-ionic-keyboard)
+# Reasons for Wattcost use:
+- Used as `disableScroll` was removed from [`cordova-plugin-ionic-keyboard`](https://github.com/ionic-team/cordova-plugin-ionic-keyboard)
+- Renamed namespace from `cordova.plugins.Keyboard` to `cordova.plugins.KeyboardUtils` to prevent detection by Ionic-v1, which was breaking iOS Keychain autofill
 ## Forked to apply fixes:
   - Hardware keyboard auto-blur: https://github.com/ionic-team/ionic-plugin-keyboard/pull/290
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic-plugin-keyboard",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "cordova": {
     "id": "ionic-plugin-keyboard",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="ionic-plugin-keyboard"
-    version="2.2.1">
+    version="3.0.0">
     <name>Keyboard</name>
     <description>Ionic Keyboard Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
     <!-- android -->
     <platform name="android">
         <js-module src="www/android/keyboard.js" name="keyboard">
-            <clobbers target="cordova.plugins.Keyboard" />
+            <clobbers target="cordova.plugins.KeyboardUtils" />
         </js-module>
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="Keyboard">
@@ -29,7 +29,7 @@
     <!-- ios -->
     <platform name="ios">
         <js-module src="www/ios/keyboard.js" name="keyboard">
-            <clobbers target="cordova.plugins.Keyboard" />
+            <clobbers target="cordova.plugins.KeyboardUtils" />
         </js-module>
         <config-file target="config.xml" parent="/*">
             <feature name="Keyboard">
@@ -43,7 +43,7 @@
 	<!-- browser -->
     <platform name="browser">
         <js-module src="www/browser/keyboard.js" name="keyboard">
-            <clobbers target="cordova.plugins.Keyboard" />
+            <clobbers target="cordova.plugins.KeyboardUtils" />
         </js-module>
     </platform>
 
@@ -60,7 +60,7 @@
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/KeyboardProxy.js" name="KeyboardProxy">
-            <clobbers target="cordova.plugins.Keyboard" />
+            <clobbers target="cordova.plugins.KeyboardUtils" />
         </js-module>
     </platform>
 

--- a/src/blackberry10/index.js
+++ b/src/blackberry10/index.js
@@ -31,11 +31,11 @@ module.exports = {
 };
 
 keyboardShow = function(a){
-	_webview.executeJavascript("cordova.plugins.Keyboard.isVisible = true");
+	_webview.executeJavascript("cordova.plugins.KeyboardUtils.isVisible = true");
 	_webview.executeJavascript("cordova.fireDocumentEvent('native.keyboardshow',"+a+")");
 };
 keyboardHide = function(){
-	_webview.executeJavascript("cordova.plugins.Keyboard.isVisible = false");
+	_webview.executeJavascript("cordova.plugins.KeyboardUtils.isVisible = false");
 	_webview.executeJavascript("cordova.fireDocumentEvent('native.keyboardhide','')");
 };
 onStart = function() {

--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -40,7 +40,7 @@
                                         CGRect keyboardFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
                                         keyboardFrame = [self.viewController.view convertRect:keyboardFrame fromView:nil];
 
-                                        [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.plugins.Keyboard.isVisible = true; cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
+                                        [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.plugins.KeyboardUtils.isVisible = true; cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
 
                                         //deprecated
                                         [weakSelf.commandDelegate evalJs:[NSString stringWithFormat:@"cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': %@ }); ", [@(keyboardFrame.size.height) stringValue]]];
@@ -53,7 +53,7 @@
                                queue:[NSOperationQueue mainQueue]
                                usingBlock:^(NSNotification* notification) {
                                     if (self.keyboardIsVisible) {
-                                        [weakSelf.commandDelegate evalJs:@"cordova.plugins.Keyboard.isVisible = false; cordova.fireWindowEvent('native.keyboardhide'); "];
+                                        [weakSelf.commandDelegate evalJs:@"cordova.plugins.KeyboardUtils.isVisible = false; cordova.fireWindowEvent('native.keyboardhide'); "];
 
                                         //deprecated
                                         [weakSelf.commandDelegate evalJs:@"cordova.fireWindowEvent('native.hidekeyboard'); "];

--- a/src/windows/KeyboardProxy.js
+++ b/src/windows/KeyboardProxy.js
@@ -6,7 +6,7 @@ var keyboardScrollDisabled = false;
 
 inputPane.addEventListener('hiding', function() {
     cordova.fireWindowEvent('native.keyboardhide');
-    cordova.plugins.Keyboard.isVisible = false;
+    cordova.plugins.KeyboardUtils.isVisible = false;
 });
 
 inputPane.addEventListener('showing', function(e) {
@@ -15,7 +15,7 @@ inputPane.addEventListener('showing', function(e) {
         e.ensuredFocusedElementInView = true;
     }
     cordova.fireWindowEvent('native.keyboardshow', { keyboardHeight: e.occludedRect.height });
-    cordova.plugins.Keyboard.isVisible = true;
+    cordova.plugins.KeyboardUtils.isVisible = true;
 });
 
 module.exports.disableScroll = function (disable) {

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -39,13 +39,13 @@ channel.onCordovaReady.subscribe(function() {
         var action = msg.charAt(0);
         if ( action === 'S' ) {
             var keyboardHeight = msg.substr(1);
-            cordova.plugins.Keyboard.isVisible = true;
+            cordova.plugins.KeyboardUtils.isVisible = true;
             cordova.fireWindowEvent('native.keyboardshow', { 'keyboardHeight': + keyboardHeight });
 
             //deprecated
             cordova.fireWindowEvent('native.showkeyboard', { 'keyboardHeight': + keyboardHeight });
         } else if ( action === 'H' ) {
-            cordova.plugins.Keyboard.isVisible = false;
+            cordova.plugins.KeyboardUtils.isVisible = false;
             cordova.fireWindowEvent('native.keyboardhide');
 
             //deprecated


### PR DESCRIPTION
https://wattcost.atlassian.net/browse/RHL-2702

## ⚠️ Caution ⚠️: Will break previous versions of Wattcost mobile app, as they do not specify plugin version

Rename plugin namespace to prevent detection by Ionic-v1, as it breaks iOS keychain autofilling.

Tag: `3.0.0` should be updated to `master` after merging.